### PR TITLE
add FEEL to script discovery resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,24 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.2.2</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Currently, after generating the jar with `mvn package`, FEEL engine is not being included on the Java script factory discovery resource file: `META-INF/services/javax.script.ScriptEngineFactory`.

If the factories are not included there, they can't be used on runtime even if the jar is included on the build (https://docs.oracle.com/javase/8/docs/api/javax/script/compact2-package-summary.html).

Currently only Groovy's script factory is included `org.codehaus.groovy.jsr223.GroovyScriptEngineFactory`.

This change appends FEEL's script factories to the same resource file:
```
org.camunda.feel.script.FeelScriptEngineFactory
org.camunda.feel.script.FeelUnaryTestsScriptEngineFactory
```